### PR TITLE
Lower version 0.1.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AstroAngles"
 uuid = "5c4adb95-c1fc-4c53-b4ea-2a94080c53d2"
 authors = ["Miles Lucas <mdlucas@hawaii.edu> and contributors"]
-version = "0.2.0"
+version = "0.1.4"
 
 [compat]
 julia = "1.6"


### PR DESCRIPTION
Downgrade version number 0.2.0 to 0.1.4, the assumed breaking release (Julia compat tightening) is non-breaking. SemVer disallows version removal, so next breaking change should be numbered v0.3.0 (or v0.2.1 ?).

Proposed fix to issue #6.