### PR TITLE
Handling of Missing values

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,4 @@
 name: CI
-
 on:
   push:
     branches: [main]
@@ -7,9 +6,23 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
 
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6'
+          - '1'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,49 +1,31 @@
 name: CI
+
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
 
-  test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - '1.6'
-          - '1'
-          - 'nightly'
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        arch:
-          - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
-        with:
-          file: lcov.info
+    - uses: actions/checkout@v3
+    - name: Set up Julia
+      uses: julia-actions/setup-julia@v1
+      with:
+        version: '1.5'
+    - name: Cache Julia packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.julia/artifacts
+        key: ${{ runner.os }}-julia-${{ hashFiles('**/Project.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-julia-
+    - name: Install dependencies
+      run: julia --project -e 'using Pkg; Pkg.instantiate()'
+    - name: Run tests
+      run: julia --project -e 'using Pkg; Pkg.test()'

--- a/README.md
+++ b/README.md
@@ -158,6 +158,43 @@ julia> format_angle(deg2hms(-65.0); delim=["h", "m", "s"])
 "-4h19m59.999999999998934s"
 ```
 
+### Handling Missing Values
+
+All angle parsing, conversion, and formatting functions support `Missing` input values and propagate them correctly, returning `missing` as output. This behavior allows these functions to be used smoothly in operations with potentially missing data, such as when working with DataFrames that contain missing values.
+
+```julia
+julia> using AstroAngles, Missing
+
+# Parsing functions
+julia> parse_dms(missing)
+missing
+
+julia> parse_hms(missing)
+missing
+
+# Conversion functions
+julia> rad2ha(missing)
+missing
+
+julia> deg2dms(missing)
+missing
+
+julia> dms2rad(missing, missing, missing)
+missing
+
+julia> hms2deg("12:30:45"), hms2deg(missing)
+(187.6875, missing)
+
+# Formatting function
+julia> format_angle(missing)
+missing
+
+julia> format_angle(deg2dms(45.0)), format_angle(missing)
+("45:0:0.0", missing)
+```
+
+This feature ensures type stability when working with data that may contain missing values, which is particularly useful in data analysis workflows involving astronomical data where some measurements might be unavailable.
+
 ### Example: reading coordinates from a table
 
 Here's an example of reading sky coordinates from a CSV formatted target list and converting them to degrees-

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -191,6 +191,42 @@ julia> dec_d = @. dms2deg(table.dec)
  -11.203611111111112
 [...]
 ```
+### Handling Missing Values
+
+All angle parsing, conversion, and formatting functions support `Missing` input values and propagate them correctly, returning `missing` as output. This behavior allows these functions to be used smoothly in operations with potentially missing data, such as when working with DataFrames that contain missing values.
+
+```julia
+julia> using AstroAngles, Missing
+
+# Parsing functions
+julia> parse_dms(missing)
+missing
+
+julia> parse_hms(missing)
+missing
+
+# Conversion functions
+julia> rad2ha(missing)
+missing
+
+julia> deg2dms(missing)
+missing
+
+julia> dms2rad(missing, missing, missing)
+missing
+
+julia> hms2deg("12:30:45"), hms2deg(missing)
+(187.6875, missing)
+
+# Formatting function
+julia> format_angle(missing)
+missing
+
+julia> format_angle(deg2dms(45.0)), format_angle(missing)
+("45:0:0.0", missing)
+```
+
+This feature ensures type stability when working with data that may contain missing values, which is particularly useful in data analysis workflows involving astronomical data where some measurements might be unavailable.
 
 ## Contributing/Support
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -191,21 +191,24 @@ julia> dec_d = @. dms2deg(table.dec)
  -11.203611111111112
 [...]
 ```
+
 ### Handling Missing Values
 
 All angle parsing, conversion, and formatting functions support `Missing` input values and propagate them correctly, returning `missing` as output. This behavior allows these functions to be used smoothly in operations with potentially missing data, such as when working with DataFrames that contain missing values.
 
-```julia
-julia> using AstroAngles, Missing
+```jldoctest
+julia> using AstroAngles
 
-# Parsing functions
+julia> # Parsing functions
+
 julia> parse_dms(missing)
 missing
 
 julia> parse_hms(missing)
 missing
 
-# Conversion functions
+julia> # Conversion functions
+
 julia> rad2ha(missing)
 missing
 
@@ -218,7 +221,8 @@ missing
 julia> hms2deg("12:30:45"), hms2deg(missing)
 (187.6875, missing)
 
-# Formatting function
+julia> # Formatting function
+
 julia> format_angle(missing)
 missing
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -15,37 +15,51 @@ const RADIANS_PER_HOUR = π / 12
 """
     rad2ha(angle)
 
-Convert radians to hour angles
+Convert radians to hour angles.
+
+If `angle` is `Missing`, returns `missing`.
 """
 rad2ha(angle) = angle * HOURS_PER_RADIAN
+rad2ha(::Missing) = missing
 
 """
     rad2dms(angle)
 
-Convert radians to (degrees, arcminutes, arcseconds) tuple
+Convert radians to (degrees, arcminutes, arcseconds) tuple.
+
+If `angle` is `Missing`, returns `missing`.
 """
 rad2dms(angle) = rad2deg(angle) |> deg2dms
+rad2dms(::Missing) = missing
 
 """
     rad2hms(angle)
 
-Convert radians to (hours, minutes, seconds) tuple
+Convert radians to (hours, minutes, seconds) tuple.
+
+If `angle` is `Missing`, returns `missing`.
 """
 rad2hms(angle) = rad2ha(angle) |> ha2hms
+rad2hms(::Missing) = missing
 
 ### deg2xxx
 
 """
     deg2ha(angle)
 
-Convert degrees to hour angles
+Convert degrees to hour angles.
+
+If `angle` is `Missing`, returns `missing`.
 """
 deg2ha(angle) = angle * HOURS_PER_DEGREE
+deg2ha(::Missing) = missing
 
 """
     deg2dms(angle)
 
-Convert degrees to (degrees, arcminutes, arcseconds) tuple
+Convert degrees to (degrees, arcminutes, arcseconds) tuple.
+
+If `angle` is `Missing`, returns `missing`.
 """
 function deg2dms(angle)
     remain_degrees, degrees = modf(angle)
@@ -54,34 +68,46 @@ function deg2dms(angle)
     arcsec = remain_arcmin * 60
     return degrees, arcmin, arcsec
 end
+deg2dms(::Missing) = missing
 
 """
     deg2hms(angle)
 
-Convert degrees to (hours, minutes, seconds) tuple
+Convert degrees to (hours, minutes, seconds) tuple.
+
+If `angle` is `Missing`, returns `missing`.
 """
 deg2hms(angle) = deg2ha(angle) |> ha2hms
+deg2hms(::Missing) = missing
 
 ### ha2xxx
 
 """
     ha2rad(angle)
 
-Convert hour angles to radians
+Convert hour angles to radians.
+
+If `angle` is `Missing`, returns `missing`.
 """
 ha2rad(angle) = angle * RADIANS_PER_HOUR
+ha2rad(::Missing) = missing
 
 """
     ha2deg(angle)
 
-Convert hour angles to degrees
+Convert hour angles to degrees.
+
+If `angle` is `Missing`, returns `missing`.
 """
 ha2deg(angle) = angle * DEGREES_PER_HOUR
+ha2deg(::Missing) = missing
 
 """
     ha2hms(angle)
 
-Convert hour angles to (hours, minutes, seconds) tuple
+Convert hour angles to (hours, minutes, seconds) tuple.
+
+If `angle` is `Missing`, returns `missing`.
 """
 function ha2hms(angle)
     remain_hours, hours = modf(angle)
@@ -90,13 +116,17 @@ function ha2hms(angle)
     seconds = remain_min * 60
     return hours, minutes, seconds
 end
+ha2hms(::Missing) = missing
 
 """
     ha2dms(angle)
 
-Convert hour angles to (degrees, arcminutes, arcseconds) tuple
+Convert hour angles to (degrees, arcminutes, arcseconds) tuple.
+
+If `angle` is `Missing`, returns `missing`.
 """
 ha2dms(angle) = ha2deg(angle) |> deg2dms
+ha2dms(::Missing) = missing
 
 ### dms2xxx
 
@@ -108,11 +138,14 @@ ha2dms(angle) = ha2deg(angle) |> deg2dms
 Convert (degrees, arcminutes, arcseconds) tuple to degrees. If a string is
 given, will parse with [`parse_dms`](@ref) first. If an angle is input will
 treat as a no-op.
+
+If any input is `Missing`, returns `missing`.
 """
 function dms2deg(degrees, arcminutes, arcseconds)
     frac = arcminutes * MINUTES_TO_WHOLE + arcseconds * SECONDS_TO_WHOLE
     return signbit(degrees) ? degrees - frac : degrees + frac
 end
+dms2deg(::Missing, ::Missing, ::Missing) = missing
 
 """
     dms2rad(degrees, arcmin, arcsec)
@@ -122,8 +155,11 @@ end
 Convert (degrees, arcminutes, arcseconds) tuple to radians. If a string is
 given, will parse with [`parse_dms`](@ref) first. If an angle is input will
 treat as a no-op.
+
+If any input is `Missing`, returns `missing`.
 """
 dms2rad(degrees, arcminutes, arcseconds) = dms2deg(degrees, arcminutes, arcseconds) |> deg2rad
+dms2rad(::Missing, ::Missing, ::Missing) = missing
 
 """
     dms2ha(degrees, arcmin, arcsec)
@@ -133,13 +169,17 @@ dms2rad(degrees, arcminutes, arcseconds) = dms2deg(degrees, arcminutes, arcsecon
 Convert (degrees, arcminutes, arcseconds) tuple to hour angles. If a string is
 given, will parse with [`parse_dms`](@ref) first. If an angle is input will
 treat as a no-op.
+
+If any input is `Missing`, returns `missing`.
 """
 dms2ha(degrees, arcminutes, arcseconds) = dms2deg(degrees, arcminutes, arcseconds) |> deg2ha
+dms2ha(::Missing, ::Missing, ::Missing) = missing
 
 # code-gen for string inputs and no-ops
 for func in (:dms2deg, :dms2rad, :dms2ha)
     @eval $func(input::AbstractString) = parse_dms(input) |> $func
     @eval $func(input::Number) = input
+    @eval $func(input::Missing) = missing
 end
 
 ### hms2xxx
@@ -152,11 +192,14 @@ end
 Convert (hours, minutes, seconds) tuple to hour angles. If a string is given,
 will parse with [`parse_hms`](@ref) first. If an angle is input will treat as a
 no-op.
+
+If any input is `Missing`, returns `missing`.
 """
 function hms2ha(hours, minutes, seconds)
     frac = minutes * MINUTES_TO_WHOLE + seconds * SECONDS_TO_WHOLE
     return signbit(hours) ? hours - frac : hours + frac
 end
+hms2ha(::Missing, ::Missing, ::Missing) = missing
 
 """
     hms2deg(hours, mins, secs)
@@ -166,8 +209,11 @@ end
 Convert (hours, minutes, seconds) tuple to degrees. If a string is given, will
 parse with [`parse_hms`](@ref) first. If an angle is input will treat as a
 no-op.
+
+If any input is `Missing`, returns `missing`.
 """
 hms2deg(hours, minutes, seconds) = hms2ha(hours, minutes, seconds) |> ha2deg
+hms2deg(::Missing, ::Missing, ::Missing) = missing
 
 """
     hms2rad(hours, mins, secs)
@@ -177,16 +223,21 @@ hms2deg(hours, minutes, seconds) = hms2ha(hours, minutes, seconds) |> ha2deg
 Convert (hours, minutes, seconds) tuple to radians. If a string is given, will
 parse with [`parse_hms`](@ref) first. If an angle is input will treat as a
 no-op.
+
+If any input is `Missing`, returns `missing`.
 """
 hms2rad(hours, minutes, seconds) = hms2ha(hours, minutes, seconds) |> ha2rad
+hms2rad(::Missing, ::Missing, ::Missing) = missing
 
 # code-gen for string inputs and no-ops
 for func in (:hms2deg, :hms2rad, :hms2ha)
     @eval $func(input::AbstractString) = parse_hms(input) |> $func
     @eval $func(input::Number) = input
+    @eval $func(input::Missing) = missing
 end
 
 # code-gen for accepting inputs separate or in a collection
 for func in (:dms2rad, :dms2deg, :dms2ha, :hms2rad, :hms2deg, :hms2ha)
     @eval $func(parts) = $func(parts...)
+    @eval $func(::Missing) = missing
 end

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -20,7 +20,6 @@ Convert radians to hour angles.
 If `angle` is `Missing`, returns `missing`.
 """
 rad2ha(angle) = angle * HOURS_PER_RADIAN
-rad2ha(::Missing) = missing
 
 """
     rad2dms(angle)
@@ -30,7 +29,6 @@ Convert radians to (degrees, arcminutes, arcseconds) tuple.
 If `angle` is `Missing`, returns `missing`.
 """
 rad2dms(angle) = rad2deg(angle) |> deg2dms
-rad2dms(::Missing) = missing
 
 """
     rad2hms(angle)
@@ -40,7 +38,6 @@ Convert radians to (hours, minutes, seconds) tuple.
 If `angle` is `Missing`, returns `missing`.
 """
 rad2hms(angle) = rad2ha(angle) |> ha2hms
-rad2hms(::Missing) = missing
 
 ### deg2xxx
 
@@ -52,7 +49,6 @@ Convert degrees to hour angles.
 If `angle` is `Missing`, returns `missing`.
 """
 deg2ha(angle) = angle * HOURS_PER_DEGREE
-deg2ha(::Missing) = missing
 
 """
     deg2dms(angle)
@@ -68,7 +64,6 @@ function deg2dms(angle)
     arcsec = remain_arcmin * 60
     return degrees, arcmin, arcsec
 end
-deg2dms(::Missing) = missing
 
 """
     deg2hms(angle)
@@ -78,7 +73,6 @@ Convert degrees to (hours, minutes, seconds) tuple.
 If `angle` is `Missing`, returns `missing`.
 """
 deg2hms(angle) = deg2ha(angle) |> ha2hms
-deg2hms(::Missing) = missing
 
 ### ha2xxx
 
@@ -90,7 +84,6 @@ Convert hour angles to radians.
 If `angle` is `Missing`, returns `missing`.
 """
 ha2rad(angle) = angle * RADIANS_PER_HOUR
-ha2rad(::Missing) = missing
 
 """
     ha2deg(angle)
@@ -100,7 +93,6 @@ Convert hour angles to degrees.
 If `angle` is `Missing`, returns `missing`.
 """
 ha2deg(angle) = angle * DEGREES_PER_HOUR
-ha2deg(::Missing) = missing
 
 """
     ha2hms(angle)
@@ -116,7 +108,6 @@ function ha2hms(angle)
     seconds = remain_min * 60
     return hours, minutes, seconds
 end
-ha2hms(::Missing) = missing
 
 """
     ha2dms(angle)
@@ -126,7 +117,12 @@ Convert hour angles to (degrees, arcminutes, arcseconds) tuple.
 If `angle` is `Missing`, returns `missing`.
 """
 ha2dms(angle) = ha2deg(angle) |> deg2dms
-ha2dms(::Missing) = missing
+
+for func in (:rad2ha, :rad2dms, :rad2hms,
+             :deg2ha, :deg2dms, :deg2hms,
+             :ha2rad, :ha2deg, :ha2hms, :ha2dms)
+    @eval $func(::Missing) = missing
+end
 
 ### dms2xxx
 
@@ -145,7 +141,6 @@ function dms2deg(degrees, arcminutes, arcseconds)
     frac = arcminutes * MINUTES_TO_WHOLE + arcseconds * SECONDS_TO_WHOLE
     return signbit(degrees) ? degrees - frac : degrees + frac
 end
-dms2deg(::Missing, ::Missing, ::Missing) = missing
 
 """
     dms2rad(degrees, arcmin, arcsec)
@@ -159,7 +154,6 @@ treat as a no-op.
 If any input is `Missing`, returns `missing`.
 """
 dms2rad(degrees, arcminutes, arcseconds) = dms2deg(degrees, arcminutes, arcseconds) |> deg2rad
-dms2rad(::Missing, ::Missing, ::Missing) = missing
 
 """
     dms2ha(degrees, arcmin, arcsec)
@@ -173,13 +167,12 @@ treat as a no-op.
 If any input is `Missing`, returns `missing`.
 """
 dms2ha(degrees, arcminutes, arcseconds) = dms2deg(degrees, arcminutes, arcseconds) |> deg2ha
-dms2ha(::Missing, ::Missing, ::Missing) = missing
 
 # code-gen for string inputs and no-ops
 for func in (:dms2deg, :dms2rad, :dms2ha)
     @eval $func(input::AbstractString) = parse_dms(input) |> $func
     @eval $func(input::Number) = input
-    @eval $func(input::Missing) = missing
+    @eval $func(::Missing) = missing
 end
 
 ### hms2xxx
@@ -199,7 +192,6 @@ function hms2ha(hours, minutes, seconds)
     frac = minutes * MINUTES_TO_WHOLE + seconds * SECONDS_TO_WHOLE
     return signbit(hours) ? hours - frac : hours + frac
 end
-hms2ha(::Missing, ::Missing, ::Missing) = missing
 
 """
     hms2deg(hours, mins, secs)
@@ -213,7 +205,6 @@ no-op.
 If any input is `Missing`, returns `missing`.
 """
 hms2deg(hours, minutes, seconds) = hms2ha(hours, minutes, seconds) |> ha2deg
-hms2deg(::Missing, ::Missing, ::Missing) = missing
 
 """
     hms2rad(hours, mins, secs)
@@ -227,17 +218,16 @@ no-op.
 If any input is `Missing`, returns `missing`.
 """
 hms2rad(hours, minutes, seconds) = hms2ha(hours, minutes, seconds) |> ha2rad
-hms2rad(::Missing, ::Missing, ::Missing) = missing
 
 # code-gen for string inputs and no-ops
 for func in (:hms2deg, :hms2rad, :hms2ha)
     @eval $func(input::AbstractString) = parse_hms(input) |> $func
     @eval $func(input::Number) = input
-    @eval $func(input::Missing) = missing
+    @eval $func(::Missing) = missing
 end
 
 # code-gen for accepting inputs separate or in a collection
 for func in (:dms2rad, :dms2deg, :dms2ha, :hms2rad, :hms2deg, :hms2ha)
     @eval $func(parts) = $func(parts...)
-    @eval $func(::Missing) = missing
+    @eval $func(::Missing, ::Missing, ::Missing) = missing
 end

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -1,4 +1,3 @@
-
 num = raw"\d+\.?\d*" # x.xx decimal number
 first = "([+-]?\\s?$num)" # leading digit is required, can have +- with 1 space
 deg_delims = "[°d:\\s]" # only for dms
@@ -21,6 +20,8 @@ all work and can be mixed together (the last delimiter is optional):
 ```
 if the direction is provided, "S" and "E" are considered negative (and
 "-1:0:0S" is 1 degree North)
+
+If `input` is `Missing`, returns `missing`.
 """
 function parse_dms(input)
     m = match(dms_re, strip(input))
@@ -42,6 +43,8 @@ function parse_dms(input)
     return deg, min, sec
 end
 
+parse_dms(::Missing) = missing
+
 """
     parse_hms(input)
 
@@ -53,6 +56,8 @@ is optional):
 ```
 if the direction is provided, "S" and "E" are considered negative (and "-1:0:0W"
 is 1 degree East)
+
+If `input` is `Missing`, returns `missing`.
 """
 function parse_hms(input)
     m = match(hms_re, strip(input))
@@ -73,6 +78,8 @@ function parse_hms(input)
     end
     return ha, min, sec
 end
+
+parse_hms(::Missing) = missing
 
 """
     @dms_str

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -1,4 +1,3 @@
-
 """
     format_angle(parts; delim=':')
 
@@ -9,6 +8,8 @@ outputs. Multiple delimiters can be given in a tuple or vector placed after
 their respective values. For more control over formatting, consider using
 [Printf](https://docs.julialang.org/en/v1/stdlib/Printf/) or a package like
 [Format.jl](https://github.com/JuliaString/Format.jl).
+
+If any input is `Missing`, returns `missing`.
 
 # Examples
 ```jldoctest
@@ -30,12 +31,15 @@ julia> format_angle(rad2hms(1.5), delim=["h", "m", "s"])
 """
 format_angle(angle; delim=':') = format_angle(angle, delim)
 format_angle(w, m, s; kwargs...) = format_angle((w, m, s); kwargs...)
+format_angle(::Missing; kwargs...) = missing
+format_angle(::Missing, args...; kwargs...) = missing
 
 function format_angle(angle, delim::Union{<:AbstractString, Char})
     whole, min, sec = angle
     sgn = signbit(whole) ? '-' : ""
     return string(sgn, Int(whole), delim, Int(min), delim, sec)
 end
+format_angle(::Missing, delim::Union{<:AbstractString, Char}) = missing
 
 function format_angle(angle, delims::Union{<:AbstractVector, <:Tuple})
     whole, min, sec = angle
@@ -44,3 +48,4 @@ function format_angle(angle, delims::Union{<:AbstractVector, <:Tuple})
     #return string(sgn, Int(whole), d1, Int(min), d2, sec, d3)
     return string(Int(whole), d1, Int(min), d2, sec, d3)
 end
+format_angle(::Missing, delims::Union{<:AbstractVector, <:Tuple}) = missing

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -39,7 +39,6 @@ function format_angle(angle, delim::Union{<:AbstractString, Char})
     sgn = signbit(whole) ? '-' : ""
     return string(sgn, Int(whole), delim, Int(min), delim, sec)
 end
-format_angle(::Missing, delim::Union{<:AbstractString, Char}) = missing
 
 function format_angle(angle, delims::Union{<:AbstractVector, <:Tuple})
     whole, min, sec = angle
@@ -48,4 +47,3 @@ function format_angle(angle, delims::Union{<:AbstractVector, <:Tuple})
     #return string(sgn, Int(whole), d1, Int(min), d2, sec, d3)
     return string(Int(whole), d1, Int(min), d2, sec, d3)
 end
-format_angle(::Missing, delims::Union{<:AbstractVector, <:Tuple}) = missing

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,10 +1,12 @@
 [deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
 Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Documenter = "1"
 Format = "1"
 Missings = "1"
 StableRNGs = "1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,12 +1,10 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
-Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Documenter = "1"
 Format = "1"
-Missings = "1"
 StableRNGs = "1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,10 @@
 [deps]
 Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
+Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Format = "1"
+Missings = "1"
 StableRNGs = "1"

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -25,24 +25,22 @@ end
 end
 
 @testset "missing value handling" begin
-    using Missings
-    
     # Test rad2xxx functions
     @test ismissing(rad2ha(missing))
     @test ismissing(rad2dms(missing))
     @test ismissing(rad2hms(missing))
-    
+
     # Test deg2xxx functions
     @test ismissing(deg2ha(missing))
     @test ismissing(deg2dms(missing))
     @test ismissing(deg2hms(missing))
-    
+
     # Test ha2xxx functions
     @test ismissing(ha2rad(missing))
     @test ismissing(ha2deg(missing))
     @test ismissing(ha2hms(missing))
     @test ismissing(ha2dms(missing))
-    
+
     # Test dms2xxx functions
     @test ismissing(dms2deg(missing, missing, missing))
     @test ismissing(dms2deg(missing, missing, missing))
@@ -51,7 +49,7 @@ end
     @test ismissing(dms2deg(missing))
     @test ismissing(dms2rad(missing))
     @test ismissing(dms2ha(missing))
-    
+
     # Test hms2xxx functions
     @test ismissing(hms2ha(missing, missing, missing))
     @test ismissing(hms2deg(missing, missing, missing))

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,4 +1,3 @@
-
 function test_integration(f1, f2, angles)
     reconstructed = @. f2(f1(angles))
     @test reconstructed ≈ angles
@@ -23,4 +22,41 @@ end
 )
     angles = randha(rng, 1000)
     test_integration(f1, f2, angles)
+end
+
+@testset "missing value handling" begin
+    using Missings
+    
+    # Test rad2xxx functions
+    @test ismissing(rad2ha(missing))
+    @test ismissing(rad2dms(missing))
+    @test ismissing(rad2hms(missing))
+    
+    # Test deg2xxx functions
+    @test ismissing(deg2ha(missing))
+    @test ismissing(deg2dms(missing))
+    @test ismissing(deg2hms(missing))
+    
+    # Test ha2xxx functions
+    @test ismissing(ha2rad(missing))
+    @test ismissing(ha2deg(missing))
+    @test ismissing(ha2hms(missing))
+    @test ismissing(ha2dms(missing))
+    
+    # Test dms2xxx functions
+    @test ismissing(dms2deg(missing, missing, missing))
+    @test ismissing(dms2deg(missing, missing, missing))
+    @test ismissing(dms2rad(missing, missing, missing))
+    @test ismissing(dms2ha(missing, missing, missing))
+    @test ismissing(dms2deg(missing))
+    @test ismissing(dms2rad(missing))
+    @test ismissing(dms2ha(missing))
+    
+    # Test hms2xxx functions
+    @test ismissing(hms2ha(missing, missing, missing))
+    @test ismissing(hms2deg(missing, missing, missing))
+    @test ismissing(hms2rad(missing, missing, missing))
+    @test ismissing(hms2ha(missing))
+    @test ismissing(hms2deg(missing))
+    @test ismissing(hms2rad(missing))
 end

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -59,4 +59,7 @@ end
     @test ismissing(hms2ha(missing))
     @test ismissing(hms2deg(missing))
     @test ismissing(hms2rad(missing))
+
+    # Test with partially missing values
+    @test ismissing(hms2ha(18, 23.9, missing))
 end

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -137,17 +137,15 @@ end
 end
 
 @testset "missing value handling in parsing" begin
-    using Missings
-    
     # Test parsing functions with missing values
     @test ismissing(parse_dms(missing))
     @test ismissing(parse_hms(missing))
-    
+
     # Test string inputs for dms/hms with missing values
     @test ismissing(dms2deg(missing))
     @test ismissing(dms2rad(missing))
     @test ismissing(dms2ha(missing))
-    
+
     @test ismissing(hms2deg(missing))
     @test ismissing(hms2rad(missing))
     @test ismissing(hms2ha(missing))

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -1,4 +1,3 @@
-
 DMS_FSTRINGS = FormatExpr.([
     "{1:d} {2:d} {3}",
     "{1:d}:{2:d}:{3}",
@@ -135,4 +134,21 @@ end
     @test parse_hms("10.234") == (10.234, 0.0, 0.0)
     @test parse_hms("10.234 0.1") == (10.234, 0.1, 0.0)
     @test parse_hms("10.234 0.1 0.3") == (10.234, 0.1, 0.3)
+end
+
+@testset "missing value handling in parsing" begin
+    using Missings
+    
+    # Test parsing functions with missing values
+    @test ismissing(parse_dms(missing))
+    @test ismissing(parse_hms(missing))
+    
+    # Test string inputs for dms/hms with missing values
+    @test ismissing(dms2deg(missing))
+    @test ismissing(dms2rad(missing))
+    @test ismissing(dms2ha(missing))
+    
+    @test ismissing(hms2deg(missing))
+    @test ismissing(hms2rad(missing))
+    @test ismissing(hms2ha(missing))
 end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -1,4 +1,3 @@
-
 @testset "printing" begin
     angle = 45.0
 
@@ -44,4 +43,18 @@ end
 @testset "negatives" begin
     @test format_angle(parse_dms("-0:0:1.0")) == "-0:0:1.0"
     @test format_angle(parse_hms("-0:0:1.0")) == "-0:0:1.0"
+end
+
+@testset "missing value handling in printing" begin
+    using Missings
+    
+    # Test with missing value
+    @test ismissing(format_angle(missing))
+    
+    # Test with missing value and delimiter
+    @test ismissing(format_angle(missing, delim=":"))
+    @test ismissing(format_angle(missing, delim=[" ", ":", ""]))
+    
+    # Test with tuple form
+    @test ismissing(format_angle(missing, missing, missing))
 end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -57,4 +57,7 @@ end
     
     # Test with tuple form
     @test ismissing(format_angle(missing, missing, missing))
+
+    # Test with partially missing values
+    @test ismissing(format_angle(missing, 2.39, "15"))
 end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -46,15 +46,13 @@ end
 end
 
 @testset "missing value handling in printing" begin
-    using Missings
-    
     # Test with missing value
     @test ismissing(format_angle(missing))
-    
+
     # Test with missing value and delimiter
     @test ismissing(format_angle(missing, delim=":"))
     @test ismissing(format_angle(missing, delim=[" ", ":", ""]))
-    
+
     # Test with tuple form
     @test ismissing(format_angle(missing, missing, missing))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using AstroAngles
 using Format
+using Missings
 using StableRNGs
 using Test
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using AstroAngles
 using Format
-using Missings
 using StableRNGs
 using Test
 using Documenter

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Format
 using Missings
 using StableRNGs
 using Test
+using Documenter
 
 rng = StableRNG(206265)
 
@@ -13,6 +14,9 @@ randdms(rng, Ns...) = randdegree(rng, Ns...) .|> deg2dms
 randhms(rng, Ns...) = randdegree(rng, Ns...) .|> deg2hms
 
 @testset "AstroAngles" begin
+    DocMeta.setdocmeta!(AstroAngles, :DocTestSetup, :(using AstroAngles))
+    doctest(AstroAngles)
+
     @testset "conversions" begin include("conversions.jl") end
     @testset "parsing" begin include("parsing.jl") end
     @testset "printing" begin include("printing.jl") end


### PR DESCRIPTION
### Handling Missing Values

All angle parsing, conversion, and formatting functions support `Missing` input values and propagate them correctly, returning `missing` as output. This behavior allows these functions to be used smoothly in operations with potentially missing data, such as when working with DataFrames that contain missing values.

```julia
julia> using AstroAngles, Missing

# Parsing functions
julia> parse_dms(missing)
missing

julia> parse_hms(missing)
missing

# Conversion functions
julia> rad2ha(missing)
missing

julia> deg2dms(missing)
missing

julia> dms2rad(missing, missing, missing)
missing

julia> hms2deg("12:30:45"), hms2deg(missing)
(187.6875, missing)

# Formatting function
julia> format_angle(missing)
missing

julia> format_angle(deg2dms(45.0)), format_angle(missing)
("45:0:0.0", missing)
```

This feature ensures type stability when working with data that may contain missing values, which is particularly useful in data analysis workflows involving astronomical data where some measurements might be unavailable.