### PR TITLE
feat: Right-pad fractional seconds + support variable-length parts in `format_angle`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -155,7 +155,7 @@ the above functions can take a string as input and will automatically parse it (
 
 ### Formatting angles
 
-Lastly, we have some simple methods for formatting angles into strings, although for more fine-tuned control we recommend using [Printf](https://docs.julialang.org/en/v1/stdlib/Printf/) or a package like [Format.jl](https://github.com/JuliaString/Format.jl). `format_angle` takes parts (like from `deg2dms` or `rad2hms`) and a delimiter (or collection of 3 delimiters for each value).
+Lastly, we have some simple methods for formatting angles into strings, although for more fine-tuned control we recommend using [Printf](https://docs.julialang.org/en/v1/stdlib/Printf/) or a package like [Format.jl](https://github.com/JuliaString/Format.jl). `format_angle` takes the parts of an angle (like from `deg2dms` or `rad2hms`) and a delimiter: either a single delimiter inserted between the parts, or a collection with one delimiter per part, appended after each.
 
 ```jldoctest
 julia> format_angle(deg2dms(45.0))
@@ -163,6 +163,16 @@ julia> format_angle(deg2dms(45.0))
 
 julia> format_angle(deg2hms(-65.0); delim=["h", "m", "s"])
 "-04h19m60.00s"
+```
+
+Any number of parts is supported: every part except the last is formatted as a whole number, and the last part keeps its fractional digits, controlled by the `digits` keyword (`digits=0` displays it as a whole number too). This allows partial splits like `(minutes, seconds)` as well as extended sub-arcsecond splits like `(degrees, arcminutes, arcseconds, mas, μas)`.
+
+```jldoctest
+julia> format_angle((58, 48, 12.0); delim=["°", "′", "″"], digits=0)
+"58°48′12″"
+
+julia> format_angle((23, 33.6); delim=["ᵐ", "ˢ"]) # partial (minutes, seconds) split
+"23ᵐ33.60ˢ"
 ```
 
 ### Example: reading coordinates from a table
@@ -232,6 +242,9 @@ missing
 
 julia> format_angle(deg2dms(45.0)), format_angle(missing)
 ("45:00:00.00", missing)
+
+julia> format_angle(45, missing, 3.0) # a missing part in any position
+missing
 ```
 
 This feature ensures type stability when working with data that may contain missing values, which is particularly useful in data analysis workflows involving astronomical data where some measurements might be unavailable.

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -74,7 +74,6 @@ julia> format_angle((58, 48, 12.0), delim=["°", "′", "″"]; digits=0)
 [`deg2dms`](@ref), [`deg2hms`](@ref), [`rad2dms`](@ref), [`rad2hms`](@ref), [`ha2dms`](@ref), [`ha2hms`](@ref)
 """
 format_angle(angle; delim = ':', kwargs...) = format_angle(angle, delim; kwargs...)
-format_angle(angle, delim::Union{<:AbstractString, Char}; kwargs...) = format_angle(angle, [delim]; kwargs...)
 format_angle(part1::Real, rest::Vararg{Union{Real, Missing}}; kwargs...) = format_angle((part1, rest...); kwargs...)
 format_angle(::Missing; kwargs...) = missing
 format_angle(::Missing, args...; kwargs...) = missing
@@ -83,16 +82,33 @@ format_angle(::Missing, args...; kwargs...) = missing
 format_angle(::Missing, ::Union{<:AbstractString, Char}; kwargs...) = missing
 format_angle(::Missing, ::Union{<:AbstractVector, <:Tuple}; kwargs...) = missing
 
-function format_angle(angle, delim::Union{<:AbstractVector, <:Tuple}; digits::Union{Int, String} = 2, pad::Bool = true, alwayssign::Bool = false)
+# A scalar delimiter is inserted between the parts.
+function format_angle(angle, delim::Union{<:AbstractString, Char}; kwargs...)
+    formatted = _format_angle_parts(angle; kwargs...)
+    formatted === missing && return missing
+    sgn, strs = formatted
+    return string(sgn, join(strs, delim))
+end
+
+# A collection of delimiters is appended after each respective part, and must
+# therefore contain exactly one delimiter per part.
+function format_angle(angle, delim::Union{<:AbstractVector, <:Tuple}; kwargs...)
+    formatted = _format_angle_parts(angle; kwargs...)
+    formatted === missing && return missing
+    sgn, strs = formatted
+    length(delim) == length(strs) || throw(
+        ArgumentError(
+            "delimiter collection must have one delimiter per angle part ($(length(strs))), got $(length(delim))"
+        )
+    )
+    return string(sgn, join(string.(strs, delim)))
+end
+
+function _format_angle_parts(angle; digits::Union{Int, String} = 2, pad::Bool = true, alwayssign::Bool = false)
     parts = Tuple(angle)
     n = length(parts)
     n >= 1 || throw(ArgumentError("angle must have at least one part"))
     any(ismissing, parts) && return missing
-    length(delim) in (1, n) || throw(
-        ArgumentError(
-            "delimiter must have 1 or $n elements (one per angle part), got $(length(delim))"
-        )
-    )
 
     sgn = signbit(first(parts)) ? '-' : (alwayssign ? '+' : "")
 
@@ -117,10 +133,5 @@ function format_angle(angle, delim::Union{<:AbstractVector, <:Tuple}; digits::Un
     end
     strs[n] = str
 
-    printout = if length(delim) == 1
-        join(strs, delim[begin])
-    else
-        join(string.(strs, delim))
-    end
-    return string(sgn, printout)
+    return sgn, strs
 end

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -82,7 +82,13 @@ function format_angle(angle, delim::Union{<:AbstractVector, <:Tuple}; digits::Un
     sec = digits == "all" ? sec : round(sec; digits)
     if pad
         whole, min = lpad.((whole, min), 2, "0")
-        sec = join(lpad.(split("$sec", "."), 2, "0"), ".")
+        intfrac = split(string(sec), '.')
+        sec = lpad(intfrac[1], 2, "0")
+        if length(intfrac) == 2
+            # Fractional digits are padded on the right, e.g. 30.5 -> "30.50"
+            frac = digits isa Int ? rpad(intfrac[2], digits, "0") : intfrac[2]
+            sec = sec * "." * frac
+        end
     end
 
     angle = string.((whole, min, sec))

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -1,12 +1,20 @@
 """
     format_angle(parts; delim = ':', digits = 2, pad = true, alwayssign = false)
-    format_angle(whole, minutes, seconds; kwargs...)
+    format_angle(parts...; kwargs...)
 
-Format the `(whole, minutes, seconds)` `parts` of an angle into a delimited
-string. The parts are typically produced by the [`deg2dms`](@ref),
+Format the parts of an angle into a delimited string. The parts are typically
+the `(whole, minutes, seconds)` produced by the [`deg2dms`](@ref),
 [`deg2hms`](@ref), [`rad2dms`](@ref), [`rad2hms`](@ref), [`ha2dms`](@ref), and
-[`ha2hms`](@ref) methods, and may be passed either as a single tuple or as three
-separate positional arguments. For more control over formatting, consider using
+[`ha2hms`](@ref) methods, and may be passed either as a single tuple (or
+vector) or as separate positional arguments.
+
+Any number of parts is supported: every part except the last is formatted as a
+whole number, and the last part keeps its fractional digits. This allows
+extended sub-arcsecond splits like `(degrees, arcminutes, arcseconds, mas,
+μas)` as well as partial splits like `(minutes, seconds)`. The sign of the
+angle is taken from the first part, matching the convention of the conversion
+methods above, which carry the sign only on their first part. For more control
+over formatting, consider using
 [Printf](https://docs.julialang.org/en/v1/stdlib/Printf/) or a package like
 [Format.jl](https://github.com/JuliaString/Format.jl).
 
@@ -15,13 +23,14 @@ If any part is `missing`, returns `missing`.
 # Keyword arguments
 - `delim`: The delimiter(s) placed between the parts. A single `Char`/`String`
   (default `':'`) is inserted between each part, e.g. `"45:00:00.00"`. A vector
-  or tuple of three delimiters is instead appended after each respective part,
-  e.g., `delim = ["h", "m", "s"]` gives `"05h43m46.48s"`. Only 1 or 3 delimiters
-  are accepted.
-- `digits`: The number of digits to round the seconds to (default `2`). Pass
-  `"all"` to keep full precision without rounding.
-- `pad`: If `true` (default), zero-pad each part to at least two characters,
-  e.g. `"03:00:00.00"`.
+  or tuple with one delimiter per part is instead appended after each
+  respective part, e.g., `delim = ["h", "m", "s"]` gives `"05h43m46.48s"`.
+- `digits`: The number of digits to round the last part to (default `2`). Pass
+  `0` to display it as a whole number, or `"all"` to keep full precision
+  without rounding.
+- `pad`: If `true` (default), zero-pad the whole-number portion of each part to
+  at least two characters and the fractional digits of the last part to
+  `digits`, e.g. `"03:00:00.00"`.
 - `alwayssign`: If `true`, prefix non-negative angles with `'+'` (default
   `false`). Negative angles are always prefixed with `'-'`.
 
@@ -53,6 +62,12 @@ julia> format_angle(deg2dms(45.0); alwayssign=true)
 
 julia> format_angle(deg2dms(-45.0); alwayssign=true)
 "-45:00:00.00"
+
+julia> format_angle((23, 33.6), delim=["ᵐ", "ˢ"]) # partial split
+"23ᵐ33.60ˢ"
+
+julia> format_angle((58, 48, 12.0), delim=["°", "′", "″"]; digits=0)
+"58°48′12″"
 ```
 
 # See also
@@ -60,7 +75,7 @@ julia> format_angle(deg2dms(-45.0); alwayssign=true)
 """
 format_angle(angle; delim = ':', kwargs...) = format_angle(angle, delim; kwargs...)
 format_angle(angle, delim::Union{<:AbstractString, Char}; kwargs...) = format_angle(angle, [delim]; kwargs...)
-format_angle(w, m, s; kwargs...) = format_angle((w, m, s); kwargs...)
+format_angle(part1::Real, rest::Vararg{Union{Real, Missing}}; kwargs...) = format_angle((part1, rest...); kwargs...)
 format_angle(::Missing; kwargs...) = missing
 format_angle(::Missing, args...; kwargs...) = missing
 # Disambiguate a `missing` angle against the typed `delim` methods above so
@@ -69,33 +84,43 @@ format_angle(::Missing, ::Union{<:AbstractString, Char}; kwargs...) = missing
 format_angle(::Missing, ::Union{<:AbstractVector, <:Tuple}; kwargs...) = missing
 
 function format_angle(angle, delim::Union{<:AbstractVector, <:Tuple}; digits::Union{Int, String} = 2, pad::Bool = true, alwayssign::Bool = false)
-    whole, min, sec, delim = angle..., delim
-    length(delim) in (1, 3) || throw(
+    parts = Tuple(angle)
+    n = length(parts)
+    n >= 1 || throw(ArgumentError("angle must have at least one part"))
+    any(ismissing, parts) && return missing
+    length(delim) in (1, n) || throw(
         ArgumentError(
-            "delimiter must have 1 or 3 elements, got $(length(delim))"
+            "delimiter must have 1 or $n elements (one per angle part), got $(length(delim))"
         )
     )
-    sgn = signbit(whole) ? '-' : (alwayssign ? '+' : "")
 
-    whole, min = trunc.(Int, (whole, min))
-    whole = abs(whole)  # sign handled separately via sgn
-    sec = digits == "all" ? sec : round(sec; digits)
+    sgn = signbit(first(parts)) ? '-' : (alwayssign ? '+' : "")
+
+    strs = Vector{String}(undef, n)
+    # Every part except the last is a whole number. The sign is handled
+    # separately via `sgn`.
+    for i in 1:(n - 1)
+        v = trunc(Int, i == 1 ? abs(parts[i]) : parts[i])
+        strs[i] = pad ? lpad(v, 2, "0") : string(v)
+    end
+    val = n == 1 ? abs(parts[n]) : parts[n]
+    val = digits == "all" ? val : digits == 0 ? round(Int, val) : round(val; digits)
+    str = string(val)
     if pad
-        whole, min = lpad.((whole, min), 2, "0")
-        intfrac = split(string(sec), '.')
-        sec = lpad(intfrac[1], 2, "0")
+        intfrac = split(str, '.')
+        str = lpad(intfrac[1], 2, "0")
         if length(intfrac) == 2
             # Fractional digits are padded on the right, e.g. 30.5 -> "30.50"
             frac = digits isa Int ? rpad(intfrac[2], digits, "0") : intfrac[2]
-            sec = sec * "." * frac
+            str *= "." * frac
         end
     end
+    strs[n] = str
 
-    angle = string.((whole, min, sec))
     printout = if length(delim) == 1
-        join(angle, delim[begin])
+        join(strs, delim[begin])
     else
-        string(angle[1], delim[1], angle[2], delim[2], angle[3], delim[3])
+        join(string.(strs, delim))
     end
-    return string(sgn, printout...)
+    return string(sgn, printout)
 end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -14,7 +14,7 @@
     catch e
         e
     end
-    @test occursin("1 or 3", err.msg)
+    @test occursin("one delimiter per angle part (3), got 2", err.msg)
 end
 
 function test_print_integration(angles, f1, f2)
@@ -117,6 +117,9 @@ end
     # Single part
     @test format_angle((45.671,)) == "45.67"
     @test format_angle(-45.671) == "-45.67"
+    # A single-element delimiter collection is still appended (not treated as
+    # a between-parts separator, which would drop it)
+    @test format_angle((33.6,), delim = ["ˢ"]) == "33.60ˢ"
 
     # digits=0 displays the last part as a whole number
     @test format_angle((58, 48, 12.0), delim = ["°", "′", "″"], digits = 0) == "58°48′12″"
@@ -125,12 +128,12 @@ end
     @test format_angle((-45, 30, 10, 5, 2.0), delim = ["°", "'", "\"", "mas", "μas"]) ==
         "-45°30'10\"05mas02.00μas"
 
-    # Delimiter count must be 1 or match the number of parts
+    # Delimiter collections must have one delimiter per part
     @test_throws ArgumentError format_angle((1, 2, 3, 4.0), delim = ["a", "b", "c"])
     err = try
         format_angle((1, 2, 3, 4.0), delim = ["a", "b", "c"])
     catch e
         e
     end
-    @test occursin("1 or 4", err.msg)
+    @test occursin("one delimiter per angle part (4), got 3", err.msg)
 end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -89,6 +89,11 @@ end
 
     # Test with partially missing values
     @test ismissing(format_angle(missing, 2.39, "15"))
+
+    # A missing part anywhere returns missing (not just in first position)
+    @test ismissing(format_angle(2.39, missing, 15))
+    @test ismissing(format_angle((1, missing, 3.0)))
+    @test ismissing(format_angle((1, 2, missing), delim = ["h", "m", "s"]))
 end
 
 @testset "fractional digit padding" begin
@@ -98,4 +103,34 @@ end
     @test format_angle((10, 20, 30.5); digits = 4) == "10:20:30.5000"
     # Unpadded values keep their natural representation
     @test format_angle((10, 20, 30.5); pad = false) == "10:20:30.5"
+end
+
+@testset "variable-length parts" begin
+    # Partial splits, e.g. (minutes, seconds)
+    @test format_angle((23, 33.6), delim = ["ᵐ", "ˢ"]) == "23ᵐ33.60ˢ"
+    @test format_angle(23, 33.6) == "23:33.60"
+
+    # Extended sub-arcsecond splits, e.g. (deg, arcmin, arcsec, mas, μas)
+    @test format_angle((58, 48, 12, 345, 200.0), delim = ["°", "'", "\"", "mas", "μas"]) ==
+        "58°48'12\"345mas200.00μas"
+
+    # Single part
+    @test format_angle((45.671,)) == "45.67"
+    @test format_angle(-45.671) == "-45.67"
+
+    # digits=0 displays the last part as a whole number
+    @test format_angle((58, 48, 12.0), delim = ["°", "′", "″"], digits = 0) == "58°48′12″"
+
+    # Sign is taken from the first part only
+    @test format_angle((-45, 30, 10, 5, 2.0), delim = ["°", "'", "\"", "mas", "μas"]) ==
+        "-45°30'10\"05mas02.00μas"
+
+    # Delimiter count must be 1 or match the number of parts
+    @test_throws ArgumentError format_angle((1, 2, 3, 4.0), delim = ["a", "b", "c"])
+    err = try
+        format_angle((1, 2, 3, 4.0), delim = ["a", "b", "c"])
+    catch e
+        e
+    end
+    @test occursin("1 or 4", err.msg)
 end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -90,3 +90,12 @@ end
     # Test with partially missing values
     @test ismissing(format_angle(missing, 2.39, "15"))
 end
+
+@testset "fractional digit padding" begin
+    # Fractional digits are padded on the right: 30.5 is 30.50, not 30.05
+    @test format_angle((10, 20, 30.5)) == "10:20:30.50"
+    @test format_angle((10, 20, 30.05)) == "10:20:30.05"
+    @test format_angle((10, 20, 30.5); digits = 4) == "10:20:30.5000"
+    # Unpadded values keep their natural representation
+    @test format_angle((10, 20, 30.5); pad = false) == "10:20:30.5"
+end


### PR DESCRIPTION
1. **Right-pad fractional digits of seconds**: Format_angle left-padded the fractional part, so e.g. `30.5s` is formatted as `30.05` instead of `30.50`.
1. **Support any number of angle parts in `format_angle`**: All parts except the last format as whole numbers. The last keeps its fractional digits (or none with the new `digits = 0`). Enables partial splits like `(min, sec)` and extended splits like `(deg, arcmin, arcsec, mas, μas)`. Also makes a missing part in any position return missing, as documented.